### PR TITLE
Warning fixes

### DIFF
--- a/actions.zil
+++ b/actions.zil
@@ -1598,7 +1598,7 @@ N ,PNUMB "." CR>
 		<TELL
 "To the south, across a narrow corridor, is a prison cell." CR>)>>
 
-<ROUTINE DIAL ("AUX" N)
+<ROUTINE DIAL ()
 	 <COND (<VERB? EXAMINE>
 		<TELL "The dial points to " N ,PNUMB "." CR>)
 	       (<VERB? TURN>
@@ -1940,7 +1940,7 @@ A legend beneath the picture says \"The Dungeon and Treasury of Zork.\"" CR>)
 <ROUTINE TORCH-PSEUDO ()
 	 <TELL "The torches are out of reach." CR>>
 
-<ROUTINE WATER-FCN ("AUX" AV PI?)
+<ROUTINE WATER-FCN ("AUX" PI?)
 	 #DECL ((AV) <OR OBJECT FALSE> (PI?) <OR ATOM FALSE>)
 	 <COND (<VERB? SGIVE> <RFALSE>)
 	       (<VERB? THROUGH>
@@ -2044,7 +2044,7 @@ moment, you are awakening, as if from a deep slumber." CR>)>
 	 <KILL-INTERRUPTS>
 	 <RFATAL>>
 
-<ROUTINE RANDOMIZE-OBJECTS ("AUX" (R <>) F N L)
+<ROUTINE RANDOMIZE-OBJECTS ("AUX" (R <>) F N)
 	 <SET N <FIRST? ,WINNER>>
 	 <REPEAT ()
 		 <SET F .N>
@@ -4638,7 +4638,7 @@ and algae." CR>)
 	 <GOTO ,VIEW-ROOM <>>
 	 <RTRUE>>
 
-<ROUTINE VIEWING-TABLE-F ("AUX" L)
+<ROUTINE VIEWING-TABLE-F ()
 	 <COND (<VERB? RUB>
 		<SETG SCORE <+ ,SCORE ,VIEW-POINT>>
 		<SETG VIEW-POINT 0>


### PR DESCRIPTION
This fixes most - not all - of the warnings produced by ZILF 0.9. I think this is a good idea, because otherwise warnings and errors tend to get lost in the noise.

The remaining warnings are:

```
[warning ZIL0210] ../zork-substrate/verbs.zil:526: local variable 'LST' is never used
[warning ZIL0210] ../zork-substrate/verbs.zil:526: local variable 'MAX' is never used
[warning ZIL0210] ../zork-substrate/verbs.zil:526: local variable 'CNT' is never used
[warning ZIL0210] ../zork-substrate/verbs.zil:996: local variable 'LOCN' is never used
```

I have not included the warnings fixed by https://github.com/the-infocom-files/zork-substrate/pull/6
